### PR TITLE
test: add integration and web layer tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Każda faza zawiera **cel**, **zakres** oraz **kryteria ukończenia (DoD)**, kt�
 ---
 
 ## 🐳 Docker Compose (skrót)
-- postgres 16
+- postgres 17
 - backend, frontend, ai-service
 - minio
 - prometheus + grafana

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,17 +26,22 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-database-postgresql'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-validation'
+        implementation 'org.flywaydb:flyway-core'
+        implementation 'org.flywaydb:flyway-database-postgresql'
+        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testImplementation 'org.springframework.security:spring-security-test'
+        testImplementation 'org.testcontainers:junit-jupiter'
+        testImplementation 'org.testcontainers:postgresql'
+        testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/pl/kalin/dreamlog/dream/controller/DreamEntryController.java
+++ b/backend/src/main/java/pl/kalin/dreamlog/dream/controller/DreamEntryController.java
@@ -3,6 +3,7 @@ package pl.kalin.dreamlog.dream.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 import pl.kalin.dreamlog.dream.model.DreamEntry;
 import pl.kalin.dreamlog.dream.repository.DreamEntryRepository;
 
@@ -29,12 +30,12 @@ public class DreamEntryController {
     }
 
     @PostMapping
-    public DreamEntry create(@RequestBody DreamEntry dream) {
+    public DreamEntry create(@Valid @RequestBody DreamEntry dream) {
         return repository.save(dream);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<DreamEntry> update(@PathVariable UUID id, @RequestBody DreamEntry dream) {
+    public ResponseEntity<DreamEntry> update(@PathVariable UUID id, @Valid @RequestBody DreamEntry dream) {
         if (!repository.existsById(id)) {
             return ResponseEntity.notFound().build();
         }

--- a/backend/src/main/java/pl/kalin/dreamlog/dream/model/DreamEntry.java
+++ b/backend/src/main/java/pl/kalin/dreamlog/dream/model/DreamEntry.java
@@ -1,6 +1,8 @@
 package pl.kalin.dreamlog.dream.model;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -25,13 +27,17 @@ public class DreamEntry {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @NotNull
     private User user;
 
+    @NotNull
     private LocalDate date;
 
+    @NotBlank
     private String title;
 
     @Column(columnDefinition = "text")
+    @NotBlank
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/backend/src/main/java/pl/kalin/dreamlog/user/User.java
+++ b/backend/src/main/java/pl/kalin/dreamlog/user/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -22,6 +23,9 @@ public class User {
     @GeneratedValue
     private UUID id;
 
+    @NotBlank
     private String username;
+
+    @NotBlank
     private String email;
 }

--- a/backend/src/test/java/pl/kalin/dreamlog/DreamlogApplicationTests.java
+++ b/backend/src/test/java/pl/kalin/dreamlog/DreamlogApplicationTests.java
@@ -3,7 +3,10 @@ package pl.kalin.dreamlog;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest()
-class DreamlogApplicationTests {
+@SpringBootTest
+class DreamlogApplicationTests extends IntegrationTestBase {
 
+    @Test
+    void contextLoads() {
+    }
 }

--- a/backend/src/test/java/pl/kalin/dreamlog/IntegrationTestBase.java
+++ b/backend/src/test/java/pl/kalin/dreamlog/IntegrationTestBase.java
@@ -1,0 +1,21 @@
+package pl.kalin.dreamlog;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class IntegrationTestBase {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:17-alpine");
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+}

--- a/backend/src/test/java/pl/kalin/dreamlog/OpenApiSpecTests.java
+++ b/backend/src/test/java/pl/kalin/dreamlog/OpenApiSpecTests.java
@@ -1,0 +1,26 @@
+package pl.kalin.dreamlog;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc(addFilters = false)
+class OpenApiSpecTests extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldExposeOpenApiSpec() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.openapi").exists());
+    }
+}

--- a/backend/src/test/java/pl/kalin/dreamlog/dream/controller/DreamEntryControllerTests.java
+++ b/backend/src/test/java/pl/kalin/dreamlog/dream/controller/DreamEntryControllerTests.java
@@ -1,0 +1,96 @@
+package pl.kalin.dreamlog.dream.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import pl.kalin.dreamlog.dream.model.DreamEntry;
+import pl.kalin.dreamlog.dream.model.Mood;
+import pl.kalin.dreamlog.dream.repository.DreamEntryRepository;
+import pl.kalin.dreamlog.user.User;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DreamEntryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DreamEntryControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private DreamEntryRepository repository;
+
+    @Test
+    void shouldReturnAllDreams() throws Exception {
+        User user = User.builder().id(UUID.randomUUID()).username("john").email("john@example.com").build();
+        DreamEntry dream = DreamEntry.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .date(LocalDate.of(2024, 1, 1))
+                .title("Title")
+                .content("Content")
+                .moodInDream(Mood.HAPPY)
+                .build();
+        given(repository.findAll()).willReturn(List.of(dream));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/dreams"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("Title"))
+                .andExpect(jsonPath("$[0].user.username").value("john"));
+    }
+
+    @Test
+    void shouldValidateDreamOnCreate() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/dreams")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenMissing() throws Exception {
+        UUID id = UUID.randomUUID();
+        given(repository.findById(id)).willReturn(Optional.empty());
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/dreams/" + id))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldCreateDream() throws Exception {
+        User user = User.builder().id(UUID.randomUUID()).username("john").email("john@example.com").build();
+        DreamEntry dream = DreamEntry.builder()
+                .id(UUID.randomUUID())
+                .user(user)
+                .date(LocalDate.of(2024, 1, 1))
+                .title("Title")
+                .content("Content")
+                .build();
+        given(repository.save(any(DreamEntry.class))).willReturn(dream);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/dreams")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dream)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Title"));
+
+        verify(repository).save(any(DreamEntry.class));
+    }
+}

--- a/backend/src/test/java/pl/kalin/dreamlog/dream/repository/DreamEntryRepositoryTests.java
+++ b/backend/src/test/java/pl/kalin/dreamlog/dream/repository/DreamEntryRepositoryTests.java
@@ -1,0 +1,64 @@
+package pl.kalin.dreamlog.dream.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import pl.kalin.dreamlog.IntegrationTestBase;
+import pl.kalin.dreamlog.dream.model.DreamEntry;
+import pl.kalin.dreamlog.user.User;
+import pl.kalin.dreamlog.user.UserRepository;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class DreamEntryRepositoryTests extends IntegrationTestBase {
+
+    @Autowired
+    private DreamEntryRepository dreamEntryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void shouldPerformCrudOperations() {
+        User user = userRepository.save(User.builder().username("john").email("john@example.com").build());
+
+        DreamEntry dream = dreamEntryRepository.save(DreamEntry.builder()
+                .user(user)
+                .date(LocalDate.now())
+                .title("First")
+                .content("It was vivid")
+                .build());
+
+        assertThat(dreamEntryRepository.findById(dream.getId())).contains(dream);
+
+        dream.setTitle("Updated");
+        dreamEntryRepository.save(dream);
+        assertThat(dreamEntryRepository.findById(dream.getId())).get()
+                .extracting(DreamEntry::getTitle)
+                .isEqualTo("Updated");
+
+        dreamEntryRepository.deleteById(dream.getId());
+        assertThat(dreamEntryRepository.findById(dream.getId())).isEmpty();
+    }
+
+    @Test
+    void shouldEnforceNotNullConstraintFromMigration() {
+        User user = userRepository.save(User.builder().username("kate").email("kate@example.com").build());
+
+        assertThatThrownBy(() -> jdbcTemplate.update(
+                "insert into dream_entry(id, user_id, date, title, content) values (?,?,?,?,?)",
+                UUID.randomUUID(), user.getId(), LocalDate.now(), null, "content"))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- add OpenAPI generation and Testcontainers dependencies
- introduce integration test base with PostgreSQL container
- cover repositories, controllers, and OpenAPI endpoint with tests
- use Postgres 17 for integration tests

## Testing
- `./gradlew test` *(fails: Previous attempts to find a Docker environment failed. Will not retry. Please see logs and check configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bfed5448a4832badd7a9b9d9497659