### PR TITLE
feat: enhance frontend styling and theme

### DIFF
--- a/frontend/src/app/app.scss
+++ b/frontend/src/app/app.scss
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  height: 100%;
+}

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { App } from './app';
 
@@ -6,6 +7,7 @@ describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [provideRouter([])],
     }).compileComponents();
   });
 

--- a/frontend/src/app/core/app-shell.html
+++ b/frontend/src/app/core/app-shell.html
@@ -1,9 +1,26 @@
-<mat-toolbar color="primary" class="gap-4">
-  <span class="font-bold">Dreamlog</span>
-  <span class="flex-1"></span>
-  <app-search-bar class="w-64"></app-search-bar>
-  <button mat-icon-button aria-label="Settings" routerLink="/settings">
-    <mat-icon>settings</mat-icon>
-  </button>
-</mat-toolbar>
-<router-outlet></router-outlet>
+<mat-sidenav-container class="h-full">
+  <mat-sidenav #drawer class="w-64" mode="over">
+    <mat-nav-list>
+      <a mat-list-item routerLink="/dreams" (click)="drawer.close()">Dreams</a>
+      <a mat-list-item routerLink="/calendar" (click)="drawer.close()">Calendar</a>
+    </mat-nav-list>
+  </mat-sidenav>
+
+  <mat-sidenav-content class="flex flex-col h-full">
+    <mat-toolbar color="primary" class="gap-4">
+      <button mat-icon-button class="md:hidden" aria-label="Menu" (click)="drawer.toggle()">
+        <mat-icon>menu</mat-icon>
+      </button>
+      <span class="font-bold">Dreamlog</span>
+      <span class="flex-1"></span>
+      <app-search-bar class="hidden md:block w-64"></app-search-bar>
+      <button mat-icon-button aria-label="Settings" routerLink="/settings">
+        <mat-icon>settings</mat-icon>
+      </button>
+    </mat-toolbar>
+    <mat-progress-bar *ngIf="loading$ | async" mode="indeterminate"></mat-progress-bar>
+    <main class="p-4 md:p-8 flex-1 max-w-7xl mx-auto w-full">
+      <router-outlet></router-outlet>
+    </main>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/frontend/src/app/core/app-shell.scss
+++ b/frontend/src/app/core/app-shell.scss
@@ -1,0 +1,7 @@
+:host {
+  @apply block h-full;
+}
+
+mat-sidenav-container {
+  @apply h-full;
+}

--- a/frontend/src/app/core/app-shell.ts
+++ b/frontend/src/app/core/app-shell.ts
@@ -1,17 +1,55 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { AsyncPipe, NgIf, CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatListModule } from '@angular/material/list';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { RouterOutlet } from '@angular/router';
+import {
+  Router,
+  RouterOutlet,
+  RouterLink,
+  NavigationStart,
+  NavigationEnd,
+  NavigationCancel,
+  NavigationError,
+} from '@angular/router';
+import { filter, map } from 'rxjs';
 
 import { SearchBar } from './search-bar';
 
 @Component({
   selector: 'app-app-shell',
-  imports: [RouterOutlet, MatToolbarModule, MatButtonModule, MatIconModule, MatSnackBarModule, SearchBar],
+  imports: [
+    RouterOutlet,
+    RouterLink,
+    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSidenavModule,
+    MatListModule,
+    MatProgressBarModule,
+    SearchBar,
+    CommonModule,
+    NgIf,
+    AsyncPipe,
+  ],
   templateUrl: './app-shell.html',
   styleUrls: ['./app-shell.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AppShell {}
+export class AppShell {
+  private router = inject(Router);
+
+  loading$ = this.router.events.pipe(
+    filter(
+      (e) =>
+        e instanceof NavigationStart ||
+        e instanceof NavigationEnd ||
+        e instanceof NavigationCancel ||
+        e instanceof NavigationError,
+    ),
+    map((e) => e instanceof NavigationStart),
+  );
+}

--- a/frontend/src/app/core/search-bar.html
+++ b/frontend/src/app/core/search-bar.html
@@ -1,8 +1,4 @@
-<mat-icon>search</mat-icon>
-<input
-  matInput
-  [formControl]="control"
-  type="search"
-  placeholder="Search dreams"
-  class="w-full ml-2"
-/>
+<mat-form-field appearance="outline" class="w-full">
+  <mat-icon matPrefix>search</mat-icon>
+  <input matInput [formControl]="control" type="search" placeholder="Search dreams" />
+</mat-form-field>

--- a/frontend/src/app/core/search-bar.ts
+++ b/frontend/src/app/core/search-bar.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { debounceTime } from 'rxjs';
@@ -8,10 +9,10 @@ import { SearchService } from './services/search.service';
 
 @Component({
   selector: 'app-search-bar',
-  imports: [ReactiveFormsModule, MatInputModule, MatIconModule],
+  imports: [ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatIconModule],
   templateUrl: './search-bar.html',
   styleUrls: ['./search-bar.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SearchBar {
   private search = inject(SearchService);

--- a/frontend/src/app/features/calendar/calendar-page.html
+++ b/frontend/src/app/features/calendar/calendar-page.html
@@ -1,1 +1,5 @@
-<mat-calendar></mat-calendar>
+<div class="flex justify-center p-4">
+  <mat-card class="p-4">
+    <mat-calendar></mat-calendar>
+  </mat-card>
+</div>

--- a/frontend/src/app/features/calendar/calendar-page.ts
+++ b/frontend/src/app/features/calendar/calendar-page.ts
@@ -1,11 +1,12 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 
 @Component({
   selector: 'app-calendar-page',
-  imports: [MatDatepickerModule],
+  imports: [MatDatepickerModule, MatCardModule],
   templateUrl: './calendar-page.html',
   styleUrls: ['./calendar-page.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CalendarPage {}

--- a/frontend/src/app/features/dreams/dream-detail.html
+++ b/frontend/src/app/features/dreams/dream-detail.html
@@ -1,9 +1,27 @@
-<div *ngIf="dream$ | async as dream">
-  <h2 class="text-2xl mb-2">{{ dream.title }}</h2>
-  <div class="text-sm text-gray-500 mb-4">{{ dream.date | date }}</div>
-  <app-tag-chips [tags]="dream.tags"></app-tag-chips>
-  <p class="mt-4 whitespace-pre-line">{{ dream.content }}</p>
-  <div class="mt-6 flex gap-2">
-    <button mat-button [routerLink]="['/dreams', dream.id, 'edit']">Edit</button>
+<ng-container *ngIf="dream$ | async as dream; else loading">
+  <mat-card class="max-w-3xl mx-auto p-4 md:p-8 space-y-4">
+    <div>
+      <h2 class="text-3xl font-semibold mb-1">{{ dream.title }}</h2>
+      <div class="text-sm text-gray-500">{{ dream.date | date }}</div>
+    </div>
+    <mat-card-content>
+      <p class="whitespace-pre-line leading-relaxed">{{ dream.content }}</p>
+      <app-tag-chips class="mt-4" [tags]="dream.tags"></app-tag-chips>
+    </mat-card-content>
+    <mat-card-actions class="flex justify-end">
+      <button mat-flat-button color="primary" [routerLink]="['/dreams', dream.id, 'edit']">
+        Edit
+      </button>
+    </mat-card-actions>
+  </mat-card>
+</ng-container>
+
+<ng-template #loading>
+  <div class="max-w-3xl mx-auto p-4 md:p-8">
+    <mat-card class="p-4 animate-pulse space-y-4">
+      <div class="h-6 bg-gray-200 w-1/3"></div>
+      <div class="h-4 bg-gray-200 w-1/4"></div>
+      <div class="h-32 bg-gray-100"></div>
+    </mat-card>
   </div>
-</div>
+</ng-template>

--- a/frontend/src/app/features/dreams/dream-detail.ts
+++ b/frontend/src/app/features/dreams/dream-detail.ts
@@ -1,6 +1,7 @@
 import { AsyncPipe, CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { switchMap } from 'rxjs';
 
@@ -9,16 +10,14 @@ import { TagChips } from '../../shared/tag-chips';
 
 @Component({
   selector: 'app-dream-detail',
-  imports: [AsyncPipe, MatButtonModule, RouterLink, TagChips, CommonModule],
+  imports: [AsyncPipe, MatButtonModule, MatCardModule, RouterLink, TagChips, CommonModule],
   templateUrl: './dream-detail.html',
   styleUrls: ['./dream-detail.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DreamDetail {
   private route = inject(ActivatedRoute);
   private dreams = inject(DreamsService);
 
-  dream$ = this.route.paramMap.pipe(
-    switchMap((params) => this.dreams.get(params.get('id')!))
-  );
+  dream$ = this.route.paramMap.pipe(switchMap((params) => this.dreams.get(params.get('id')!)));
 }

--- a/frontend/src/app/features/dreams/dream-edit.html
+++ b/frontend/src/app/features/dreams/dream-edit.html
@@ -1,32 +1,34 @@
-<form [formGroup]="form" (ngSubmit)="save()" class="flex flex-col gap-4">
-  <mat-form-field>
-    <mat-label>Title</mat-label>
-    <input matInput formControlName="title" />
-  </mat-form-field>
+<mat-card class="max-w-2xl mx-auto p-4 md:p-6">
+  <form [formGroup]="form" (ngSubmit)="save()" class="flex flex-col gap-4">
+    <mat-form-field>
+      <mat-label>Title</mat-label>
+      <input matInput formControlName="title" />
+    </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>Date</mat-label>
-    <input matInput [matDatepicker]="picker" formControlName="date" />
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-datepicker #picker></mat-datepicker>
-  </mat-form-field>
+    <mat-form-field>
+      <mat-label>Date</mat-label>
+      <input matInput [matDatepicker]="picker" formControlName="date" />
+      <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+      <mat-datepicker #picker></mat-datepicker>
+    </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>Tags (comma separated)</mat-label>
-    <input matInput formControlName="tags" />
-  </mat-form-field>
+    <mat-form-field>
+      <mat-label>Tags (comma separated)</mat-label>
+      <input matInput formControlName="tags" />
+    </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>Mood</mat-label>
-    <mat-select formControlName="mood">
-      <mat-option *ngFor="let m of [1,2,3,4,5]" [value]="m">{{ m }}</mat-option>
-    </mat-select>
-  </mat-form-field>
+    <mat-form-field>
+      <mat-label>Mood</mat-label>
+      <mat-select formControlName="mood">
+        <mat-option *ngFor="let m of [1, 2, 3, 4, 5]" [value]="m">{{ m }}</mat-option>
+      </mat-select>
+    </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>Content</mat-label>
-    <textarea matInput rows="5" formControlName="content"></textarea>
-  </mat-form-field>
+    <mat-form-field>
+      <mat-label>Content</mat-label>
+      <textarea matInput rows="5" formControlName="content"></textarea>
+    </mat-form-field>
 
-  <button mat-flat-button color="primary" type="submit">Save</button>
-</form>
+    <button mat-flat-button color="primary" type="submit">Save</button>
+  </form>
+</mat-card>

--- a/frontend/src/app/features/dreams/dream-edit.ts
+++ b/frontend/src/app/features/dreams/dream-edit.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -18,11 +19,12 @@ import { DreamsService } from '../../core/services/dreams.service';
     MatDatepickerModule,
     MatNativeDateModule,
     MatSelectModule,
-    MatButtonModule
+    MatButtonModule,
+    MatCardModule,
   ],
   templateUrl: './dream-edit.html',
   styleUrls: ['./dream-edit.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DreamEdit {
   private fb = inject(FormBuilder);
@@ -33,18 +35,21 @@ export class DreamEdit {
     content: ['', Validators.required], // eslint-disable-line @typescript-eslint/unbound-method
     date: [new Date(), Validators.required], // eslint-disable-line @typescript-eslint/unbound-method
     tags: [''],
-    mood: [3, Validators.required] // eslint-disable-line @typescript-eslint/unbound-method
-    });
+    mood: [3, Validators.required], // eslint-disable-line @typescript-eslint/unbound-method
+  });
 
   save() {
     if (this.form.valid) {
       const value = this.form.getRawValue();
-      const tags = value.tags ? value.tags.split(',').map((t) => t.trim()).filter(Boolean) : [];
-      this.dreams
-        .create({ ...value, date: value.date.toISOString(), tags })
-        .subscribe(() => {
-          this.form.markAsPristine();
-        });
+      const tags = value.tags
+        ? value.tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean)
+        : [];
+      this.dreams.create({ ...value, date: value.date.toISOString(), tags }).subscribe(() => {
+        this.form.markAsPristine();
+      });
     }
   }
 

--- a/frontend/src/app/features/dreams/dream-list.html
+++ b/frontend/src/app/features/dreams/dream-list.html
@@ -1,10 +1,34 @@
-<div *ngFor="let dream of dreams$ | async">
-  <mat-card class="mb-4" [routerLink]="['/dreams', dream.id]">
-    <mat-card-title>{{ dream.title }}</mat-card-title>
-    <mat-card-subtitle>{{ dream.date | date }}</mat-card-subtitle>
-    <mat-card-content>
-      <p>{{ dream.content | slice:0:100 }}...</p>
-      <app-tag-chips [tags]="dream.tags"></app-tag-chips>
-    </mat-card-content>
-  </mat-card>
-</div>
+<ng-container *ngIf="dreams$ | async as dreams; else loading">
+  <ng-container *ngIf="dreams.length; else empty">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <mat-card
+        *ngFor="let dream of dreams"
+        class="cursor-pointer hover:shadow transition-shadow"
+        [routerLink]="['/dreams', dream.id]"
+      >
+        <mat-card-header class="pb-0">
+          <mat-card-title class="text-lg font-semibold truncate">{{ dream.title }}</mat-card-title>
+          <mat-card-subtitle>{{ dream.date | date }}</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content class="pt-2">
+          <p class="text-sm text-gray-600 mb-2">{{ dream.content | slice: 0 : 120 }}...</p>
+          <app-tag-chips [tags]="dream.tags"></app-tag-chips>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  </ng-container>
+</ng-container>
+
+<ng-template #loading>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <mat-card *ngFor="let _ of skeletons" class="p-4 animate-pulse space-y-2">
+      <div class="h-5 bg-gray-200 rounded w-1/2"></div>
+      <div class="h-4 bg-gray-200 rounded w-1/3"></div>
+      <div class="h-20 bg-gray-100 rounded"></div>
+    </mat-card>
+  </div>
+</ng-template>
+
+<ng-template #empty>
+  <app-empty-state message="No dreams yet"></app-empty-state>
+</ng-template>

--- a/frontend/src/app/features/dreams/dream-list.ts
+++ b/frontend/src/app/features/dreams/dream-list.ts
@@ -5,15 +5,26 @@ import { RouterLink } from '@angular/router';
 
 import { DreamsService } from '../../core/services/dreams.service';
 import { TagChips } from '../../shared/tag-chips';
+import { EmptyState } from '../../shared/empty-state';
 
 @Component({
   selector: 'app-dream-list',
-  imports: [NgFor, AsyncPipe, MatCardModule, RouterLink, TagChips, DatePipe, CommonModule],
+  imports: [
+    NgFor,
+    AsyncPipe,
+    MatCardModule,
+    RouterLink,
+    TagChips,
+    DatePipe,
+    CommonModule,
+    EmptyState,
+  ],
   templateUrl: './dream-list.html',
   styleUrls: ['./dream-list.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DreamList {
   private dreams = inject(DreamsService);
   dreams$ = this.dreams.list();
+  skeletons = Array.from({ length: 4 });
 }

--- a/frontend/src/app/features/login/login.html
+++ b/frontend/src/app/features/login/login.html
@@ -1,5 +1,15 @@
-<div class="h-full flex items-center justify-center">
-  <a mat-flat-button color="primary" href="/api/oauth2/authorization/google">
-    Sign in with Google
-  </a>
+<div class="h-full flex items-center justify-center p-4">
+  <mat-card class="w-full max-w-sm p-6 space-y-4 text-center">
+    <h1 class="text-2xl font-semibold">Welcome to Dreamlog</h1>
+    <p class="text-sm text-gray-600">Sign in to start logging your dreams.</p>
+    <a
+      mat-flat-button
+      color="primary"
+      class="w-full flex items-center justify-center gap-2"
+      href="/api/oauth2/authorization/google"
+    >
+      <mat-icon>login</mat-icon>
+      Continue with Google
+    </a>
+  </mat-card>
 </div>

--- a/frontend/src/app/features/login/login.ts
+++ b/frontend/src/app/features/login/login.ts
@@ -1,11 +1,13 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-login',
-  imports: [MatButtonModule],
+  imports: [MatButtonModule, MatCardModule, MatIconModule],
   templateUrl: './login.html',
   styleUrls: ['./login.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Login {}

--- a/frontend/src/app/features/not-found/not-found-page.html
+++ b/frontend/src/app/features/not-found/not-found-page.html
@@ -1,4 +1,6 @@
-<div class="p-8 text-center">
-  <h2 class="text-2xl mb-4">Page not found</h2>
-  <a routerLink="/" class="text-blue-500 underline">Go home</a>
+<div class="flex justify-center p-8">
+  <mat-card class="p-6 text-center space-y-4">
+    <mat-card-title>Page not found</mat-card-title>
+    <a mat-flat-button color="primary" routerLink="/">Go home</a>
+  </mat-card>
 </div>

--- a/frontend/src/app/features/not-found/not-found-page.ts
+++ b/frontend/src/app/features/not-found/not-found-page.ts
@@ -1,11 +1,13 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-not-found-page',
-  imports: [RouterLink],
+  imports: [RouterLink, MatCardModule, MatButtonModule],
   templateUrl: './not-found-page.html',
   styleUrls: ['./not-found-page.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NotFoundPage {}

--- a/frontend/src/app/features/search/search-page.html
+++ b/frontend/src/app/features/search/search-page.html
@@ -1,1 +1,3 @@
-<div class="p-4">Searching for "{{ query$ | async }}"...</div>
+<div class="p-4">
+  <mat-card class="p-4">Searching for "{{ query$ | async }}"...</mat-card>
+</div>

--- a/frontend/src/app/features/search/search-page.ts
+++ b/frontend/src/app/features/search/search-page.ts
@@ -1,14 +1,15 @@
 import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
 
 import { SearchService } from '../../core/services/search.service';
 
 @Component({
   selector: 'app-search-page',
-  imports: [AsyncPipe],
+  imports: [AsyncPipe, MatCardModule],
   templateUrl: './search-page.html',
   styleUrls: ['./search-page.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SearchPage {
   private search = inject(SearchService);

--- a/frontend/src/app/features/settings/settings-page.html
+++ b/frontend/src/app/features/settings/settings-page.html
@@ -1,3 +1,5 @@
-<div class="p-4">
-  <mat-slide-toggle (change)="toggleTheme($event.checked)">Dark mode</mat-slide-toggle>
+<div class="max-w-md mx-auto p-4">
+  <mat-card class="p-4">
+    <mat-slide-toggle (change)="toggleTheme($event.checked)">Dark mode</mat-slide-toggle>
+  </mat-card>
 </div>

--- a/frontend/src/app/features/settings/settings-page.ts
+++ b/frontend/src/app/features/settings/settings-page.ts
@@ -1,12 +1,13 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 @Component({
   selector: 'app-settings-page',
-  imports: [MatSlideToggleModule],
+  imports: [MatSlideToggleModule, MatCardModule],
   templateUrl: './settings-page.html',
   styleUrls: ['./settings-page.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SettingsPage {
   toggleTheme(checked: boolean) {

--- a/frontend/src/app/shared/tag-chips.html
+++ b/frontend/src/app/shared/tag-chips.html
@@ -1,3 +1,3 @@
-<mat-chip-set aria-label="Tags">
+<mat-chip-set aria-label="Tags" class="flex flex-wrap gap-1">
   <mat-chip *ngFor="let tag of tags">{{ tag }}</mat-chip>
 </mat-chip-set>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>DreamlogFrontend</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>DreamlogFrontend</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
 </html>

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,4 +1,3 @@
-
 // Include theming for Angular Material with `mat.theme()`.
 // This Sass mixin will define CSS variables that are used for styling Angular Material
 // components according to the Material 3 design spec.
@@ -7,34 +6,37 @@
 @use '@angular/material' as mat;
 
 html {
-  @include mat.theme((
-    color: (
-      primary: mat.$azure-palette,
-      tertiary: mat.$blue-palette,
-    ),
-    typography: Roboto,
-    density: 0,
-  ));
+  @include mat.theme(
+    (
+      color: (
+        primary: mat.$blue-palette,
+        tertiary: mat.$violet-palette,
+        background: (
+          surface: #ffffff,
+          background: #f8fafc,
+        ),
+      ),
+      density: 0,
+    )
+  );
 }
 
 body {
-  // Default the application to a light color theme. This can be changed to
-  // `dark` to enable the dark color theme, or to `light dark` to defer to the
-  // user's system settings.
   color-scheme: light;
-
-  // Set a default background, font and text colors for the application using
-  // Angular Material's system-level CSS variables. Learn more about these
-  // variables at https://material.angular.dev/guide/system-variables
-  background-color: var(--mat-sys-surface);
-  color: var(--mat-sys-on-surface);
+  background-color: var(--mat-sys-background);
+  color: var(--mat-sys-on-background);
   font: var(--mat-sys-body-medium);
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+}
 
-  // Reset the user agent margin.
+/* You can add global styles to this file, and also import other style files */
+@import 'tailwindcss';
+
+html,
+body {
+  height: 100%;
+}
+body {
   margin: 0;
 }
-/* You can add global styles to this file, and also import other style files */
-@import "tailwindcss";
-
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }


### PR DESCRIPTION
## Summary
- style app shell with toolbar, optional sidenav, and route progress bar
- improve login and content pages with cards, responsive grids, and skeleton states
- define Material theme with Inter font and updated palette

## Testing
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_68c731a46574832b9a57852ba24b088b